### PR TITLE
Fixed movement and collision detection

### DIFF
--- a/core/assets/maps/test.tmx
+++ b/core/assets/maps/test.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" tiledversion="1.0.1" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="12" tileheight="12" nextobjectid="10">
+<map version="1.0" tiledversion="1.0.1" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="12" tileheight="12" nextobjectid="13">
  <properties>
   <property name="mapHeight" type="int" value="10"/>
   <property name="mapWidth" type="int" value="10"/>

--- a/core/src/com/questmark/entity/Mapper.java
+++ b/core/src/com/questmark/entity/Mapper.java
@@ -15,6 +15,9 @@ public final class Mapper {
     public static final ComponentMapper<PositionComponent> POS_MAPPER
             = ComponentMapper.getFor(PositionComponent.class);
 
+    public static final ComponentMapper<PreviousPositionComponent> PREV_POS_MAPPER
+            = ComponentMapper.getFor(PreviousPositionComponent.class);
+
     public static final ComponentMapper<VelocityComponent> VEL_MAPPER
             = ComponentMapper.getFor(VelocityComponent.class);
 

--- a/core/src/com/questmark/entity/components/PreviousPositionComponent.java
+++ b/core/src/com/questmark/entity/components/PreviousPositionComponent.java
@@ -1,0 +1,36 @@
+package com.questmark.entity.components;
+
+import com.badlogic.ashley.core.Component;
+import com.badlogic.gdx.math.Vector2;
+
+/**
+ * Represents the position of an entity in (x,y) coordinates on the map before a delta time velocity update.
+ * Used for entity collision detection.
+ * Can be defined as either a {@link Vector2} or two floats x, y.
+ *
+ * @author Ming Li
+ */
+public class PreviousPositionComponent implements Component {
+
+    public float x;
+    public float y;
+
+    public PreviousPositionComponent(float x, float y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public PreviousPositionComponent(Vector2 pos) {
+        this.setPrevPos(pos);
+    }
+
+    public void setPrevPos(Vector2 pos) {
+        this.x = pos.x;
+        this.y = pos.y;
+    }
+
+    public Vector2 getPrevPos() {
+        return new Vector2(x, y);
+    }
+
+}

--- a/core/src/com/questmark/entity/entities/Player.java
+++ b/core/src/com/questmark/entity/entities/Player.java
@@ -22,6 +22,7 @@ public final class Player extends Entity {
         this.add(new PlayerComponent());
         this.add(new TextureComponent(res.getSingleTexture("player")));
         this.add(new PositionComponent(position));
+        this.add(new PreviousPositionComponent(position.x, position.y));
         this.add(new VelocityComponent(0, 0));
         this.add(new SpeedComponent(25.f));
         this.add(new BoundingBoxComponent(10, 12));

--- a/core/src/com/questmark/entity/systems/KeyInputSystem.java
+++ b/core/src/com/questmark/entity/systems/KeyInputSystem.java
@@ -51,16 +51,16 @@ public class KeyInputSystem extends EntitySystem implements KeyInputHandler {
         VelocityComponent velocity = Mapper.VEL_MAPPER.get(player);
         switch (direction) {
             case Up:
-                velocity.dy = 0.f;
+                if (velocity.dy > 0) velocity.dy = 0.f;
                 break;
             case Down:
-                velocity.dy = 0.f;
+                if (velocity.dy < 0) velocity.dy = 0.f;
                 break;
             case Left:
-                velocity.dx = 0.f;
+                if (velocity.dx < 0) velocity.dx = 0.f;
                 break;
             case Right:
-                velocity.dx = 0.f;
+                if (velocity.dx > 0) velocity.dx = 0.f;
                 break;
         }
     }

--- a/core/src/com/questmark/entity/systems/MovementSystem.java
+++ b/core/src/com/questmark/entity/systems/MovementSystem.java
@@ -6,6 +6,7 @@ import com.badlogic.ashley.core.Family;
 import com.badlogic.ashley.systems.IteratingSystem;
 import com.questmark.entity.Mapper;
 import com.questmark.entity.components.PositionComponent;
+import com.questmark.entity.components.PreviousPositionComponent;
 import com.questmark.entity.components.VelocityComponent;
 
 /**
@@ -17,14 +18,17 @@ import com.questmark.entity.components.VelocityComponent;
 public class MovementSystem extends IteratingSystem {
 
     public MovementSystem() {
-        super(Family.all(PositionComponent.class, VelocityComponent.class).get());
+        super(Family.all(PositionComponent.class, VelocityComponent.class, PreviousPositionComponent.class).get());
     }
 
     @Override
     protected void processEntity(Entity entity, float dt) {
         PositionComponent position = Mapper.POS_MAPPER.get(entity);
         VelocityComponent velocity = Mapper.VEL_MAPPER.get(entity);
+        PreviousPositionComponent prevPosition = Mapper.PREV_POS_MAPPER.get(entity);
 
+        prevPosition.x = position.x;
+        prevPosition.y = position.y;
         position.x += velocity.dx * dt;
         position.y += velocity.dy * dt;
     }

--- a/core/src/com/questmark/entity/systems/TileMapCollisionSystem.java
+++ b/core/src/com/questmark/entity/systems/TileMapCollisionSystem.java
@@ -5,11 +5,11 @@ import com.badlogic.ashley.core.EntitySystem;
 import com.badlogic.ashley.core.Family;
 import com.badlogic.ashley.systems.IteratingSystem;
 import com.badlogic.gdx.math.Rectangle;
-import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
 import com.questmark.entity.Mapper;
 import com.questmark.entity.components.BoundingBoxComponent;
 import com.questmark.entity.components.PositionComponent;
+import com.questmark.entity.components.PreviousPositionComponent;
 import com.questmark.entity.components.VelocityComponent;
 
 /**
@@ -22,13 +22,10 @@ public class TileMapCollisionSystem extends IteratingSystem {
 
     // tile map bounding boxes
     private Array<Rectangle> boundingBoxes;
-    private Vector2 nextPosition;
-    private Rectangle nextCollision;
 
     public TileMapCollisionSystem() {
-        super(Family.all(BoundingBoxComponent.class, PositionComponent.class, VelocityComponent.class).get());
-        nextPosition = new Vector2();
-        nextCollision = new Rectangle();
+        super(Family.all(BoundingBoxComponent.class, PositionComponent.class,
+                VelocityComponent.class, PreviousPositionComponent.class).get());
     }
 
     @Override
@@ -36,15 +33,15 @@ public class TileMapCollisionSystem extends IteratingSystem {
         BoundingBoxComponent boundingBox = Mapper.BOUNDING_BOX_MAPPER.get(entity);
         PositionComponent position = Mapper.POS_MAPPER.get(entity);
         VelocityComponent velocity = Mapper.VEL_MAPPER.get(entity);
+        PreviousPositionComponent prevPosition = Mapper.PREV_POS_MAPPER.get(entity);
         boundingBox.bounds.setPosition(position.getPos());
 
-        nextPosition.set(position.x + velocity.dx * dt, position.y + velocity.dy * dt);
-        nextCollision.set(nextPosition.x, nextPosition.y, boundingBox.bounds.width, boundingBox.bounds.height);
-
         for (Rectangle mapBounds : boundingBoxes) {
-            if (nextCollision.overlaps(mapBounds)) {
+            if (boundingBox.bounds.overlaps(mapBounds)) {
                 velocity.dx = 0.f;
                 velocity.dy = 0.f;
+                position.x = prevPosition.x;
+                position.y = prevPosition.y;
             }
         }
     }


### PR DESCRIPTION
Fixed movement bug where spamming movement in one axis caused the player to stop moving. Also fixed collision detection where spamming movement would allow player to move into blocked areas and sometimes the player would "stick" to collision boxes.